### PR TITLE
install-dep-gnuplot: [Windows] Install last good Gnuplot using archive

### DIFF
--- a/github-actions/install-dep-gnuplot/action.yml
+++ b/github-actions/install-dep-gnuplot/action.yml
@@ -22,8 +22,9 @@ runs:
       shell: bash
       run: |
           if ${{ toJSON( runner.os == 'Windows' ) }}; then
-            echo "::group::Install gnuplot (via choco)"
-            choco install gnuplot
-            pwsh -c 'echo "C:\Program Files\gnuplot\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append'
+            echo "::group::Install gnuplot (extract from archive)"
+            pwsh -c ' $request = Invoke-WebRequest -UserAgent Curl -Uri  "https://sourceforge.net/projects/gnuplot/files/gnuplot/5.2.8/gp528-win64-mingw.7z/download" -OutFile "gp528-win64-mingw.7z"'
+            7z x gp528-win64-mingw.7z -o..
+            pwsh -c 'echo "'$( cygpath -w $( realpath ../gnuplot/bin ) )'" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append'
             echo "::endgroup::"
           fi


### PR DESCRIPTION
Installing the latest version does not work because of a known problem
with the currently released Gnuplot 5.4.

Connects with <https://github.com/PDLPorters/PDL-Graphics-Gnuplot/issues/79>.
