### PR TITLE
Revert "work around https://github.com/actions/virtual-environments/issues/2139"

### DIFF
--- a/github-actions/install-dep-pdl-dep/action.yml
+++ b/github-actions/install-dep-pdl-dep/action.yml
@@ -8,7 +8,6 @@ runs:
         if ${{ toJSON( runner.os == 'Linux' ) }}; then
           echo "::group::Install main PDL deps (via apt-get)"
           sudo apt-get -y update && \
-            sudo apt-get remove libgd3 nginx && \
             sudo apt-get install --no-install-recommends -y build-essential libgd-dev libhdf4-alt-dev libproj-dev proj-bin libcfitsio-dev libreadline-dev libvpx-dev libgsl0-dev netpbm libnetpbm10-dev
           echo "::endgroup::"
         elif ${{ toJSON( runner.os == 'macOS' ) }}; then


### PR DESCRIPTION
This reverts commit 6e2e5b07293344ec697bdc298969a09c402904e9.

This seems to no longer be needed and is now causing conflicts with packages that need `libgd3` such as OpenCV and Gnuplot.
